### PR TITLE
chore(deps): move @testing-library/* to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "homepage": "https://tjklint.github.io",
   "packageManager": "pnpm@9.12.0",
   "dependencies": {
-    "@testing-library/jest-dom": "^6.5.0",
-    "@testing-library/react": "^16.0.1",
-    "@testing-library/user-event": "^14.5.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-github-calendar": "^4.3.0",
@@ -47,6 +44,9 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "gh-pages": "^6.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,6 @@ importers:
 
   .:
     dependencies:
-      '@testing-library/jest-dom':
-        specifier: ^6.5.0
-        version: 6.9.1
-      '@testing-library/react':
-        specifier: ^16.0.1
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@testing-library/user-event':
-        specifier: ^14.5.2
-        version: 14.6.1(@testing-library/dom@10.4.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -54,6 +45,15 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.5.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.0.1
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.27


### PR DESCRIPTION
## Summary
- Move `@testing-library/jest-dom`, `@testing-library/react`, `@testing-library/user-event` from `dependencies` to `devDependencies`.
- These packages are only referenced by test infra (`setupTests.js`, `App.test.js`); they do not belong in the production dependency graph.

## Test plan
- [x] `pnpm install` resolves cleanly
- [ ] `pnpm run build` still succeeds
- [ ] `pnpm test` (if kept) still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)