### PR TITLE
chore: remove unused SiWebpack icon and empty MainContent wrapper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,29 +29,24 @@ const AppContainer = styled.div`
   margin: 0;
 `;
 
-const MainContent = styled.div`
-`;
-
 const App: React.FC = () => {
   return (
     <Router>
       <AppContainer>
         <Header />
-        <MainContent>
-          <Hero />
-          
-          <About />
-          
-          <Resume />
-          
-          <Projects />
-          
-          {/* <Techstack /> */}
-          
-          <ContributionMap />
-          
-          <SocialLinks />
-        </MainContent>
+        <Hero />
+
+        <About />
+
+        <Resume />
+
+        <Projects />
+
+        {/* <Techstack /> */}
+
+        <ContributionMap />
+
+        <SocialLinks />
         <Footer />
       </AppContainer>
     </Router>

--- a/src/components/techstack/techstack.tsx
+++ b/src/components/techstack/techstack.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FaGithub, FaGitlab, FaDocker, FaJira, FaJava, FaPython, FaHtml5, FaCss3, FaJs, FaReact, FaDatabase, FaNodeJs } from 'react-icons/fa';
-import { SiSharp, SiCplusplus, SiPostgresql, SiMongodb, SiMysql, SiSqlite, SiSpringboot, SiRedis, SiRabbitmq, SiDotnet, SiCisco, SiHandlebarsdotjs, SiGo, SiKotlin, SiTypescript, SiScikitlearn, SiWebpack } from 'react-icons/si';
+import { SiSharp, SiCplusplus, SiPostgresql, SiMongodb, SiMysql, SiSqlite, SiSpringboot, SiRedis, SiRabbitmq, SiDotnet, SiCisco, SiHandlebarsdotjs, SiGo, SiKotlin, SiTypescript, SiScikitlearn } from 'react-icons/si';
 import './techstack.scss';
 
 const Techstack: React.FC = () => {


### PR DESCRIPTION
## Summary
- `techstack.tsx`: drop `SiWebpack` from the `react-icons/si` import; it was imported but never rendered.
- `App.tsx`: `MainContent` was a `styled.div` with an empty template literal — no styles, no semantic role. Inline its children into `AppContainer` so the tree loses a useless layer.

Note: may conflict with #380 (commented-code removal) since both touch `App.tsx`. Conflict should be a simple resolve since the edits target different regions.

## Test plan
- [x] `pnpm run build` still compiles
- [ ] Visual parity check in `pnpm start` — layout is unchanged since MainContent had no CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)