### PR TITLE
refactor(styles): extract shared gradientShift keyframes

### DIFF
--- a/src/components/about/about.scss
+++ b/src/components/about/about.scss
@@ -1,15 +1,3 @@
-@keyframes gradientShift {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
 .about-container {
   width: 80%;
   margin: 0 auto;

--- a/src/components/contribution_map/contribution_map.scss
+++ b/src/components/contribution_map/contribution_map.scss
@@ -16,18 +16,6 @@
   font-weight: 400;
 }
 
-@keyframes gradientShift {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
 .contribution-map-container {
   width: 80%;
   margin: 0 auto;

--- a/src/components/footer/footer.scss
+++ b/src/components/footer/footer.scss
@@ -1,15 +1,3 @@
-@keyframes gradientShift {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
 .footer-container {
   background: linear-gradient(135deg, #1e1e1e 0%, #2a1a3d 50%, #1e1e1e 100%);
   background-size: 200% 200%;

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -1,15 +1,3 @@
-@keyframes gradientShift {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
 .header-container {
   background: linear-gradient(135deg, rgba(30, 30, 30, 0.95) 0%, rgba(42, 26, 61, 0.95) 50%, rgba(30, 30, 30, 0.95) 100%);
   background-size: 200% 200%;

--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -2,19 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import styled, { keyframes, css } from 'styled-components';
 import spaceship from '../../assets/spaceship/webp/spaceship.webp'; // Importing spaceship image
 import talksData from '../../data/talks.json';
-
-// Animated gradient background
-const gradientShift = keyframes`
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-`;
+import { gradientShift } from '../../styles/animations';
 
 // Main container for the hero section
 const HeroContainer = styled.section`

--- a/src/components/projects/projects.scss
+++ b/src/components/projects/projects.scss
@@ -27,18 +27,6 @@
     filter: drop-shadow(0 4px 12px rgba(138, 43, 226, 0.3));
   }
 
-  @keyframes gradientShift {
-    0% {
-      background-position: 0% 50%;
-    }
-    50% {
-      background-position: 100% 50%;
-    }
-    100% {
-      background-position: 0% 50%;
-    }
-  }
-
   // Search and controls section
   .projects-controls {
     width: 100%;

--- a/src/components/resume/resume.scss
+++ b/src/components/resume/resume.scss
@@ -1,15 +1,3 @@
-@keyframes gradientShift {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
 .resume-container {
   display: flex;
   flex-direction: column;

--- a/src/components/social_links/social_links.tsx
+++ b/src/components/social_links/social_links.tsx
@@ -1,18 +1,7 @@
 import React from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 import { FaGithub, FaLinkedin, FaGlobe, FaMedium, FaDev } from 'react-icons/fa';
-
-const gradientShift = keyframes`
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-`;
+import { gradientShift } from '../../styles/animations';
 
 // Container for the entire social section
 const SocialContainer = styled.div`

--- a/src/components/techstack/techstack.scss
+++ b/src/components/techstack/techstack.scss
@@ -1,15 +1,3 @@
-@keyframes gradientShift {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
 .about-technologies-container {
   width: 80%;
   margin: 0 auto;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
+@keyframes gradientShift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
 html, body {
   margin: 0;
   padding: 0;

--- a/src/styles/animations.ts
+++ b/src/styles/animations.ts
@@ -1,0 +1,13 @@
+import { keyframes } from 'styled-components';
+
+export const gradientShift = keyframes`
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+`;


### PR DESCRIPTION
## Summary
- The same `gradientShift` `@keyframes` block was duplicated across seven SCSS files (`header`, `footer`, `projects`, `resume`, `about`, `contribution_map`, `techstack`) and two styled-components (`hero`, `social_links`).
- Define the keyframes once at the global level in `src/index.css`; every SCSS consumer resolves `animation: gradientShift ...` by name without carrying its own copy.
- Add `src/styles/animations.ts` exporting a shared styled-components `keyframes` object; `hero.tsx` and `social_links.tsx` import from it.

Net diff: **+28 / -110**.

## Test plan
- [x] `pnpm run build` compiles cleanly
- [ ] Visual parity check in `pnpm start` — every section that used the gradient animation (header, footer, all `.section-title`/heading text, hero, social links card) should look identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)