### PR TITLE
fix: drop stray <MainContent> wrapper in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,19 +32,17 @@ const App: React.FC = () => {
     <Router>
       <AppContainer>
         <Header />
-        <MainContent>
-          <Hero />
-          
-          <About />
-          
-          <Resume />
-          
-          <Projects />
+        <Hero />
 
-          <ContributionMap />
-          
-          <SocialLinks />
-        </MainContent>
+        <About />
+
+        <Resume />
+
+        <Projects />
+
+        <ContributionMap />
+
+        <SocialLinks />
         <Footer />
       </AppContainer>
     </Router>


### PR DESCRIPTION
## Summary
Main is currently unbuildable — `src/App.tsx` references `<MainContent>` JSX even though the `styled.div` declaration for it was removed. Result:

\`\`\`
src/App.tsx
  Line 35:10:  'MainContent' is not defined  react/jsx-no-undef
\`\`\`

This looks like a bad auto-resolve when #380 (commented-code removal) and #381 (MainContent removal) merged in sequence. #381's declaration removal landed, #381's JSX removal did not.

Fix: inline the children directly into `<AppContainer>`, matching the intent of #381.

## Test plan
- [x] `CI=true pnpm run build` succeeds
- [ ] `pnpm start` renders the page layout unchanged (MainContent had no CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)