### PR TITLE
feat(contribution-map): add 2026 full-width, stack 2025/2024 at half

### DIFF
--- a/src/components/contribution_map/contribution_map.scss
+++ b/src/components/contribution_map/contribution_map.scss
@@ -69,6 +69,32 @@
       }
     }
 
+    .calendar-row {
+      width: 100%;
+      display: flex;
+      flex-direction: row;
+      gap: 40px;
+
+      .calendar-section {
+        flex: 1;
+        min-width: 0;
+        margin-bottom: 0;
+      }
+
+      @media (max-width: 1024px) {
+        flex-direction: column;
+        gap: 0;
+
+        .calendar-section {
+          margin-bottom: 50px;
+
+          &:last-child {
+            margin-bottom: 0;
+          }
+        }
+      }
+    }
+
     .calendar-wrapper {
       width: 100%;
       display: flex;

--- a/src/components/contribution_map/contribution_map.tsx
+++ b/src/components/contribution_map/contribution_map.tsx
@@ -22,7 +22,7 @@ const ContributionMap: React.FC = () => {
     <div className="contribution-map-container">
       <section className="contribution-map">
         <div className="calendar-section">
-          <h3 className="year-label">/2025</h3>
+          <h3 className="year-label">/2026</h3>
           <div className="calendar-wrapper">
             <GitHubCalendar
               username="tjklint"
@@ -30,22 +30,38 @@ const ContributionMap: React.FC = () => {
               fontSize={16}
               theme={theme}
               labels={labels}
-              year={2025}
+              year={2026}
             />
           </div>
         </div>
 
-        <div className="calendar-section">
-          <h3 className="year-label">/2024</h3>
-          <div className="calendar-wrapper">
-            <GitHubCalendar
-              username="tjklint"
-              blockSize={18}
-              fontSize={16}
-              theme={theme}
-              labels={labels}
-              year={2024}
-            />
+        <div className="calendar-row">
+          <div className="calendar-section">
+            <h3 className="year-label">/2025</h3>
+            <div className="calendar-wrapper">
+              <GitHubCalendar
+                username="tjklint"
+                blockSize={11}
+                fontSize={14}
+                theme={theme}
+                labels={labels}
+                year={2025}
+              />
+            </div>
+          </div>
+
+          <div className="calendar-section">
+            <h3 className="year-label">/2024</h3>
+            <div className="calendar-wrapper">
+              <GitHubCalendar
+                username="tjklint"
+                blockSize={11}
+                fontSize={14}
+                theme={theme}
+                labels={labels}
+                year={2024}
+              />
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Add a **2026** GitHub calendar at the top, full-width (blockSize 18, fontSize 16 — same sizing 2025 had).
- Wrap 2025 and 2024 in a new `.calendar-row` flex container so they sit side-by-side at 50% each on desktops (>=1025px) and stack vertically on smaller viewports.
- Use blockSize 11 / fontSize 14 for the half-width calendars so a full year's worth of weeks fits without a horizontal scrollbar in the half column.

Makes the overall page noticeably shorter — two years of maps collapse into one row instead of stacking.

## Relationship to other PRs
This branch is rebased on top of #384 (the `<MainContent>` hotfix) since main is currently unbuildable without it. Merge #384 first and this diff will cleanly apply.

## Test plan
- [x] `CI=true pnpm run build` compiles cleanly
- [ ] Desktop (>=1025px): 2026 full-width on top, 2025 left / 2024 right underneath, no horizontal overflow
- [ ] Tablet/mobile (<=1024px): all three years stack full-width with consistent spacing
- [ ] Calendars still fetch + render GitHub data for tjklint

🤖 Generated with [Claude Code](https://claude.com/claude-code)