### PR TITLE
feat(chat-bubble): add terminal-styled floating chat trigger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,8 @@ import About from './components/about/about.tsx';
 import Footer from './components/footer/footer.tsx';
 // @ts-ignore
 import ContributionMap from './components/contribution_map/contribution_map.tsx';
+// @ts-ignore
+import ChatBubble from './components/chat_bubble/chat_bubble.tsx';
 
 const AppContainer = styled.div`
   background: linear-gradient(135deg, #1e1e1e 0%, #2a1a3d 50%, #1e1e1e 100%);
@@ -44,6 +46,7 @@ const App: React.FC = () => {
 
         <SocialLinks />
         <Footer />
+        <ChatBubble />
       </AppContainer>
     </Router>
   );

--- a/src/components/chat_bubble/chat_bubble.scss
+++ b/src/components/chat_bubble/chat_bubble.scss
@@ -1,0 +1,178 @@
+:root {
+  --chat-bubble-bottom: 24px;
+  --chat-bubble-gap: 16px;
+  --chat-bubble-height: 100px; // JS overrides on mount with the measured value
+}
+
+.chat-bubble {
+  position: fixed;
+  bottom: var(--chat-bubble-bottom);
+  right: 24px;
+  z-index: 9999;
+  width: 200px;
+  background: #0d1117;
+  border-radius: 12px;
+  border: 1px solid rgba(168, 85, 247, 0.35);
+  cursor: pointer;
+  font-family: 'RobotoMono', monospace;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5),
+              0 0 0 1px rgba(168, 85, 247, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  will-change: transform;
+
+  &:hover {
+    transform: translateY(-3px);
+    border-color: rgba(212, 161, 255, 0.6);
+    box-shadow: 0 12px 32px rgba(138, 43, 226, 0.45),
+                0 0 0 1px rgba(212, 161, 255, 0.3);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #d4a1ff;
+    outline-offset: 3px;
+  }
+
+  &.is-running .chat-bubble__status-dot {
+    background: #febc2e;
+    box-shadow: 0 0 8px rgba(254, 188, 46, 0.7);
+  }
+
+  &.is-open {
+    border-color: rgba(212, 161, 255, 0.6);
+  }
+
+  @media (max-width: 480px) {
+    width: 170px;
+    bottom: 16px;
+    right: 16px;
+  }
+}
+
+.chat-bubble__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: #161b22;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}
+
+.chat-bubble__dots {
+  display: flex;
+  gap: 4px;
+}
+
+.chat-bubble__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+
+  &--red    { background: #ff5f57; }
+  &--yellow { background: #febc2e; }
+  &--green  { background: #28c840; }
+}
+
+.chat-bubble__title {
+  font-size: 9px;
+  color: #6e7681;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.chat-bubble__body {
+  padding: 8px 10px;
+  min-height: 44px;
+}
+
+.chat-bubble__line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.chat-bubble__prompt {
+  color: #d4a1ff;
+  font-weight: 600;
+}
+
+.chat-bubble__code {
+  color: #e6edf3;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.chat-bubble__cursor {
+  color: #d4a1ff;
+  animation: chat-bubble-blink 1s steps(1) infinite;
+}
+
+@keyframes chat-bubble-blink {
+  50% { opacity: 0; }
+}
+
+.chat-bubble__output {
+  font-size: 10px;
+  color: #00ff9d;
+  margin-top: 4px;
+  padding-left: 16px;
+  min-height: 14px;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+
+  &.show {
+    opacity: 1;
+  }
+}
+
+.chat-bubble__status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  background: #161b22;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 9px;
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+}
+
+.chat-bubble__status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #00ff9d;
+  box-shadow: 0 0 6px rgba(0, 255, 157, 0.6);
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-bubble__status-text {
+  color: #6e7681;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+// Botpress webchat overrides.
+//
+// 1. Hide the default Botpress FAB — our custom bubble replaces it, so we
+//    don't want two floating buttons stacked in the corner.
+// 2. Push the webchat panel (.bpContainer) above the bubble so opening the
+//    chat doesn't hide the thing the user just clicked. The bubble's
+//    measured height is exposed as --chat-bubble-height by chat_bubble.tsx
+//    on mount.
+// Broad match — Botpress sometimes suffixes the class at build time (hashed
+// classnames, wrappers, etc.), so target any element whose class contains
+// the documented token.
+.bpFabContainer,
+[class*="bpFabContainer"] {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+
+.bpContainer {
+  bottom: calc(var(--chat-bubble-bottom) + var(--chat-bubble-height) + var(--chat-bubble-gap)) !important;
+}

--- a/src/components/chat_bubble/chat_bubble.tsx
+++ b/src/components/chat_bubble/chat_bubble.tsx
@@ -1,0 +1,208 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import './chat_bubble.scss';
+
+type Phase = 'typing' | 'running' | 'output' | 'clearing';
+type Status = 'ready' | 'running' | 'done' | 'connected';
+
+interface Command {
+  code: string;
+  output: string;
+  duration: number;
+}
+
+const COMMANDS: Command[] = [
+  { code: 'whoami',             output: '→ tj klint',              duration: 600 },
+  { code: 'tj.role',            output: '→ full-stack @ botpress', duration: 700 },
+  { code: 'tj.stack',           output: '→ ts, py, go, c#',        duration: 500 },
+  { code: 'tj.cusec',           output: '→ co-chair 2025',         duration: 600 },
+  { code: "ask('projects')",    output: '→ 9 shipped',             duration: 500 },
+  { code: 'openChat()',         output: '→ click me :)',           duration: 400 },
+];
+
+declare global {
+  interface Window {
+    botpress?: { open?: () => void };
+  }
+}
+
+const ChatBubble: React.FC = () => {
+  const [commandIndex, setCommandIndex] = useState(0);
+  const [charIndex, setCharIndex] = useState(0);
+  const [phase, setPhase] = useState<Phase>('typing');
+  const [status, setStatus] = useState<Status>('ready');
+  const [codeText, setCodeText] = useState('');
+  const [outputText, setOutputText] = useState('');
+  const [footerLift, setFooterLift] = useState(0);
+  const timeoutRef = useRef<number | null>(null);
+  const bubbleRef = useRef<HTMLDivElement | null>(null);
+
+  const openChat = useCallback(() => {
+    if (window.botpress?.open) {
+      window.botpress.open();
+      setStatus('connected');
+    }
+  }, []);
+
+  // Typing / running / output / clearing cycle
+  useEffect(() => {
+    const current = COMMANDS[commandIndex];
+
+    const run = (delay: number, fn: () => void) => {
+      timeoutRef.current = window.setTimeout(fn, delay);
+    };
+
+    if (phase === 'typing') {
+      if (charIndex < current.code.length) {
+        setCodeText(current.code.substring(0, charIndex + 1));
+        run(70 + Math.random() * 50, () => setCharIndex((c) => c + 1));
+      } else {
+        setStatus('running');
+        setPhase('running');
+      }
+    } else if (phase === 'running') {
+      run(current.duration, () => {
+        setOutputText(current.output);
+        setStatus('done');
+        setPhase('output');
+      });
+    } else if (phase === 'output') {
+      run(2000, () => {
+        setOutputText('');
+        setStatus('ready');
+        setPhase('clearing');
+      });
+    } else if (phase === 'clearing') {
+      run(300, () => {
+        setCodeText('');
+        setCharIndex(0);
+        setCommandIndex((i) => (i + 1) % COMMANDS.length);
+        setPhase('typing');
+      });
+    }
+
+    return () => {
+      if (timeoutRef.current) window.clearTimeout(timeoutRef.current);
+    };
+  }, [phase, charIndex, commandIndex]);
+
+  // Belt-and-suspenders: hide the default Botpress FAB. The CSS override
+  // handles it when the element lives in the light DOM, but Botpress renders
+  // the widget asynchronously after inject.js loads, so walk the DOM (and any
+  // shadow roots we can reach) on intervals until we find and hide it.
+  useEffect(() => {
+    let disposed = false;
+
+    const hideFab = (root: Document | ShadowRoot | HTMLElement) => {
+      const candidates = root.querySelectorAll<HTMLElement>(
+        '.bpFabContainer, [class*="bpFabContainer"]'
+      );
+      candidates.forEach((el) => {
+        el.style.setProperty('display', 'none', 'important');
+      });
+      // Descend into any shadow roots we encounter.
+      const hosts = root.querySelectorAll<HTMLElement>('*');
+      hosts.forEach((host) => {
+        if (host.shadowRoot) hideFab(host.shadowRoot);
+      });
+      return candidates.length > 0;
+    };
+
+    const interval = window.setInterval(() => {
+      if (disposed) return;
+      hideFab(document);
+    }, 500);
+
+    // Stop polling after a reasonable window; Botpress loads within seconds.
+    const stop = window.setTimeout(() => window.clearInterval(interval), 20000);
+
+    return () => {
+      disposed = true;
+      window.clearInterval(interval);
+      window.clearTimeout(stop);
+    };
+  }, []);
+
+  // Lift the bubble above the footer as the user reaches the bottom of the
+  // page, and expose the bubble's height as a CSS variable so the Botpress
+  // webchat panel can sit above it without overlap.
+  useEffect(() => {
+    const footer = document.querySelector<HTMLElement>('.footer-container');
+    const bubble = bubbleRef.current;
+    if (bubble) {
+      const h = bubble.getBoundingClientRect().height;
+      document.documentElement.style.setProperty('--chat-bubble-height', `${h}px`);
+    }
+    if (!footer) return;
+
+    const computeLift = () => {
+      const rect = footer.getBoundingClientRect();
+      const overlap = window.innerHeight - rect.top;
+      setFooterLift(Math.max(0, overlap + 16));
+    };
+
+    computeLift();
+    window.addEventListener('scroll', computeLift, { passive: true });
+    window.addEventListener('resize', computeLift);
+    return () => {
+      window.removeEventListener('scroll', computeLift);
+      window.removeEventListener('resize', computeLift);
+    };
+  }, []);
+
+  // Press "/" to open the chat (skip while typing in form fields)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      const inField = !!t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || (t as HTMLElement).isContentEditable);
+      if (e.key === '/' && !e.ctrlKey && !e.metaKey && !inField) {
+        e.preventDefault();
+        openChat();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [openChat]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      openChat();
+    }
+  };
+
+  return (
+    <div
+      ref={bubbleRef}
+      className={`chat-bubble${phase === 'running' ? ' is-running' : ''}${status === 'connected' ? ' is-open' : ''}`}
+      role="button"
+      tabIndex={0}
+      aria-label="Open chat"
+      onClick={openChat}
+      onKeyDown={handleKeyDown}
+      style={{ transform: `translateY(-${footerLift}px)` }}
+    >
+      <div className="chat-bubble__header">
+        <div className="chat-bubble__dots">
+          <span className="chat-bubble__dot chat-bubble__dot--red" />
+          <span className="chat-bubble__dot chat-bubble__dot--yellow" />
+          <span className="chat-bubble__dot chat-bubble__dot--green" />
+        </div>
+        <span className="chat-bubble__title">ask xero</span>
+      </div>
+      <div className="chat-bubble__body">
+        <div className="chat-bubble__line">
+          <span className="chat-bubble__prompt">❯</span>
+          <span className="chat-bubble__code">{codeText}</span>
+          <span className="chat-bubble__cursor">▋</span>
+        </div>
+        <div className={`chat-bubble__output${outputText ? ' show' : ''}`}>{outputText}</div>
+      </div>
+      <div className="chat-bubble__status">
+        <span className="chat-bubble__status-dot" />
+        <span className="chat-bubble__status-text">{status}</span>
+      </div>
+    </div>
+  );
+};
+
+export default ChatBubble;


### PR DESCRIPTION
## Summary
Replaces the default Botpress webchat bubble with a small fake-terminal card in the bottom-right corner, cycling through portfolio-flavored commands. Click (or press `/`) to open the Botpress webchat panel.

Ported from an earlier vanilla-HTML/JS version of the same component; rewritten as a React/TS component with SCSS styling to match the codebase.

### Commands on rotation
| Code | Output |
|---|---|
| `whoami` | `→ tj klint` |
| `tj.role` | `→ full-stack @ botpress` |
| `tj.stack` | `→ ts, py, go, c#` |
| `tj.cusec` | `→ co-chair 2025` |
| `ask('projects')` | `→ 9 shipped` |
| `openChat()` | `→ click me :)` |

## Notable bits
- **Typing animation** runs through a single `useEffect` state machine (`typing → running → output → clearing`), cleaned up on unmount.
- **Footer avoidance:** scroll + resize listener measures the footer's position each frame and translates the bubble up by `overlap + 16px` once it enters the viewport. Smooth 0.2s transform.
- **Webchat-above-bubble:** bubble's measured height is written to `--chat-bubble-height` on mount, and `.bpContainer`'s `bottom` is pinned to `calc(var(--chat-bubble-bottom) + var(--chat-bubble-height) + var(--chat-bubble-gap)) !important` so the panel always opens above the bubble without overlap.
- **Default Botpress FAB hidden two ways** because CSS alone wasn't enough:
  1. Broad selector (`.bpFabContainer, [class*=\"bpFabContainer\"]`) + `display/visibility/pointer-events` so class-hashing doesn't defeat it.
  2. JS polling fallback that walks the DOM **and any reachable shadow roots**, setting `display: none` directly on the element. Necessary because webchat v3 sometimes mounts the FAB inside a shadow root that external stylesheets can't reach. Polling self-disposes after 20s.
- **Accessibility:** `role=\"button\"`, `tabIndex={0}`, `aria-label`, Enter/Space handler, visible focus ring. The global `/` shortcut skips when the active target is an input/textarea/contentEditable.

## Test plan
- [x] `CI=true pnpm run build` succeeds
- [ ] Bubble appears bottom-right and cycles through the 6 commands
- [ ] Clicking opens the Botpress webchat panel above the bubble (not overlapping)
- [ ] Pressing `/` outside any input opens the panel; pressing `/` inside an input types normally
- [ ] Scroll to bottom: bubble lifts above the footer instead of covering it
- [ ] Only one bubble visible in the corner (default Botpress FAB hidden)
- [ ] Keyboard: Tab focuses the bubble, Enter/Space activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)