### PR TITLE
feat(resume): update experience section with accurate roles and bullet points

### DIFF
--- a/src/data/resume.json
+++ b/src/data/resume.json
@@ -14,17 +14,19 @@
         "title": "Experience",
         "entries": [
           {
-            "title": "Full Stack Developer",
+            "title": "Full-Stack Developer",
             "company": "@Botpress",
             "dates": "August 2025 - Present",
             "bulletPoints": [
-              "Developing New-Gen Agentic AI Platform"
+              "Implemented automated quota recharging system, generating $150K ARR within the first 100 days.",
+              "Led rapid development of a new Customer Experience platform in 2 months, architecting infrastructure, microservices, and full-stack systems while averaging 14 PRs/day within a 12-person team.",
+              "Built a new multi-provider rate limiter used across all systems under pressure to thwart a DDoS attack."
             ]
           },
           {
-            "title": "Software Developer",
+            "title": "Software Developer Intern",
             "company": "@Bell",
-            "dates": "May 2024 - August 2024",
+            "dates": "May 2025 - September 2025",
             "bulletPoints": [
               "Built a Retrieval-Augmented Generation (RAG) system with Elasticsearch, improving decision speed by 65%.",
               "Developed and secured 18+ API endpoints, with full audit logging and blocked malicious attempts.",
@@ -32,9 +34,9 @@
             ]
           },
           {
-            "title": "Software Developer",
+            "title": "Software Developer Intern (DevSecOps + Machine Learning)",
             "company": "@CSE (Communications Security Establishment)",
-            "dates": "January 2024 - April 2024",
+            "dates": "January 2025 - May 2025",
             "bulletPoints": [
               "Built a Jenkins pipeline to automate Docker builds and deploys to Azure/Artifactory, cutting deploy time by 80%.",
               "Integrated unit testing into CI/CD and increased test coverage by 40% as the first to implement it."
@@ -43,21 +45,20 @@
           {
             "title": "Co-Chair",
             "company": "@CUSEC (Canadian University Software Engineering Conference)",
-            "dates": "January 2024 - February 2025",
+            "dates": "April 2023 - February 2025",
             "bulletPoints": [
-              "Oversaw operations for a 15+ team of student organizers including scheduling, sponsorships, and logistics, to ensure a high-quality conference for 350+ attendees from 17+ schools across 6+ provinces..",
+              "Oversaw operations for a 15+ team of student organizers including scheduling, sponsorships, and logistics, to ensure a high-quality conference for 350+ attendees from 17+ schools across 6+ provinces.",
               "Guiding organizers, resolving logistic conflicts, and coordinating details with speakers, sponsors, and hotel venue.",
               "Handled recruiting through social media and interviewed more than 90+ applicants."
             ]
           },
           {
-            "title": "Software Developer",
+            "title": "Software Developer Intern",
             "company": "@Bell",
-            "dates": "May 2024 - August 2024",
+            "dates": "May 2024 - September 2024",
             "bulletPoints": [
               "Developed a web app to streamline internal ticket creation using the Jira API.",
-              "Utilized the MEVN stack (MongoDB, Express, Vue.js, Node.js) for development.",
-              "Enhanced efficiency of internal processes at Bell through automation."
+              "Utilized the MEVN stack (MongoDB, Express, Vue.js, Node.js), SpringBoot with Java and RabbitMQ."
             ]
           }
         ]

--- a/src/data/resume.json
+++ b/src/data/resume.json
@@ -14,9 +14,15 @@
         "title": "Experience",
         "entries": [
           {
+            "title": "Software Engineer",
+            "company": "@Planned",
+            "dates": "May 2026 - Present",
+            "bulletPoints": []
+          },
+          {
             "title": "Full-Stack Developer",
             "company": "@Botpress",
-            "dates": "August 2025 - Present",
+            "dates": "August 2025 - May 2026",
             "bulletPoints": [
               "Implemented automated quota recharging system, generating $150K ARR within the first 100 days.",
               "Led rapid development of a new Customer Experience platform in 2 months, architecting infrastructure, microservices, and full-stack systems while averaging 14 PRs/day within a 12-person team.",


### PR DESCRIPTION
## Summary

Updates `src/data/resume.json` to match the latest resume.

### Changes
| Entry | Change |
|---|---|
| **Botpress** | Replaced placeholder with 3 real impact bullets ($150K ARR, CX platform, rate limiter) |
| **Bell (2025)** | Added missing entry (May–Sep 2025) with RAG/API/DB bullet points |
| **CSE** | Fixed dates (Jan 2024 → Jan 2025, Apr → May 2025); updated title to include DevSecOps + Machine Learning |
| **CUSEC** | Fixed start date (Jan 2024 → April 2023); removed stray double period |
| **Bell (2024)** | Fixed end date (Aug → Sep 2024); updated bullets to Jira/MEVN/RabbitMQ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)